### PR TITLE
Remove setMaxListeners

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -60,11 +60,6 @@ function configurePrimus (config, configurer) {
                 app.channel(app.channels).leave(getParams(spark));
               }
             });
-
-            // In Feathers it is easy to hit the standard Node warning limit
-            // of event listeners (e.g. by registering 10 services).
-            // So we set it to a higher number. 64 should be enough for everyone.
-            primus.setMaxListeners(64);
           }
 
           if (typeof configurer === 'function') {


### PR DESCRIPTION
Related to https://github.com/primus/primus/issues/630 and https://github.com/primus/eventemitter3 which does not seem to require a `maxListener` and does not throw a memory leak error.